### PR TITLE
Panic on error in TempDir destructor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,13 @@ impl TempDir {
 
 impl Drop for TempDir {
     fn drop(&mut self) {
-        let _ = self.cleanup_dir();
+        match self.cleanup_dir() {
+            Ok(_) => (),
+            Err(e) => match e.kind() {
+                ErrorKind::NotFound => (),
+                _ => panic!(e),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This commit eliminates the silent squashing of most errors in the `TempDir`
destructor. The `NotFound` error is still ignored.

This resolves issue https://github.com/rust-lang/tempdir/issues/5.
