### PR TITLE
Add AsRef<Path> impl to TempDir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,12 @@ impl TempDir {
     }
 }
 
+impl AsRef<Path> for TempDir {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
 impl fmt::Debug for TempDir {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("TempDir")

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -205,6 +205,16 @@ fn in_tmpdir<F>(f: F) where F: FnOnce() {
     f();
 }
 
+pub fn pass_as_asref_path() {
+    let tempdir = t!(TempDir::new("test"));
+    takes_asref_path(&tempdir);
+
+    fn takes_asref_path<T: AsRef<Path>>(path: T) {
+        let path = path.as_ref();
+        assert!(path.exists());
+    }
+}
+
 #[test]
 fn main() {
     in_tmpdir(test_tempdir);
@@ -215,4 +225,5 @@ fn main() {
     in_tmpdir(recursive_mkdir_rel_2);
     in_tmpdir(test_remove_dir_all_ok);
     in_tmpdir(dont_double_panic);
+    in_tmpdir(pass_as_asref_path);
 }


### PR DESCRIPTION
It would be nice to be able to just pass the tempdir to a function that takes `AsRef<Path>` as an argument.
