### PR TITLE
Add keywords to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ A library for managing a temporary directory and deleting all contents when it's
 dropped.
 """
 categories = ["filesystem"]
+keywords = ["fs", "file", "filesystem"]
 
 [dependencies]
 rand = "0.3"


### PR DESCRIPTION
It looks like the category that was already there, `filesystem`, is pretty much the only category this would fall under, so I didn't touch that. We could have a couple more keywords, but I wasn't sure what else to apply to this particular crate.

Closes #25 