### PR TITLE
Add travis & appveyor badges to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,9 @@ dropped.
 categories = ["filesystem"]
 keywords = ["fs", "file", "filesystem"]
 
+[badges]
+travis-ci = { repository = "rust-lang-nursery/tempdir" }
+appveyor = { repository = "rust-lang-libs/tempdir" }
+
 [dependencies]
 rand = "0.3"


### PR DESCRIPTION
Because I forgot this in my PR for #24 

Closes #24 