### PR TITLE
Fix ignored error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use std::io::{self, Write};
 use std::fs::File;
 use tempdir::TempDir;
 
-fn write_temp_folder_with_files() -> Result<(), io::Error> {
+fn write_temp_folder_with_files() -> io::Result<()> {
     let dir = TempDir::new("my_directory_prefix")?;
     let file_path = dir.path().join("foo.txt");
     println!("{:?}", file_path);

--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ This sample method does the following:
 
 ```rust
 fn write_temp_folder_with_files() -> Result<(), io::Error> {
-    if let Ok(dir) = TempDir::new("my_directory_prefix") {
-        let file_path = dir.path().join("foo.txt");
-        println!("{:?}", file_path);
+    let dir = TempDir::new("my_directory_prefix")?;
+    let file_path = dir.path().join("foo.txt");
+    println!("{:?}", file_path);
 
-        let mut f = File::create(file_path)?;
-        f.write_all(b"Hello, world!")?;
-        f.sync_all()?;
-        dir.close()?;
-    }
+    let mut f = File::create(file_path)?;
+    f.write_all(b"Hello, world!")?;
+    f.sync_all()?;
+    dir.close()?;
+
     Ok(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ This sample method does the following:
 5. Close the directory, deleting the contents in the process.
 
 ```rust
+use std::io::{self, Write};
+use std::fs::File;
+use tempdir::TempDir;
+
 fn write_temp_folder_with_files() -> Result<(), io::Error> {
     let dir = TempDir::new("my_directory_prefix")?;
     let file_path = dir.path().join("foo.txt");


### PR DESCRIPTION
This PR makes three changes to the example in the README:

1. Fixes silently ignored `Err` result from `TempDir::new`
2. Adds `use` statements necessary to get example to compile
3. Simplifies the return type by using the `io:Result` type