### PR TITLE
Add deprecation note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 tempdir
 =======
 
-A Rust library for creating a temporary directory and deleting its entire
-contents when the directory is dropped.
-
 [![Build Status](https://travis-ci.org/rust-lang-nursery/tempdir.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/tempdir)
 [![Build status](https://ci.appveyor.com/api/projects/status/2mp24396db5t4hul/branch/master?svg=true)](https://ci.appveyor.com/project/rust-lang-libs/tempdir/branch/master)
 
 [Documentation](https://doc.rust-lang.org/tempdir)
+
+## Deprecation Note
+
+The `tempdir` crate is being merged into [`tempfile`](https://github.com/Stebalien/tempfile). Please see [this issue](https://github.com/Stebalien/tempfile/issues/43) to track progress and direct new issues and pull requests to `tempfile`.
+
+A Rust library for creating a temporary directory and deleting its entire
+contents when the directory is dropped.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 tempdir
 =======
 
+A Rust library for creating a temporary directory and deleting its entire
+contents when the directory is dropped.
+
 [![Build Status](https://travis-ci.org/rust-lang-nursery/tempdir.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/tempdir)
 [![Build status](https://ci.appveyor.com/api/projects/status/2mp24396db5t4hul/branch/master?svg=true)](https://ci.appveyor.com/project/rust-lang-libs/tempdir/branch/master)
 
@@ -9,9 +12,6 @@ tempdir
 ## Deprecation Note
 
 The `tempdir` crate is being merged into [`tempfile`](https://github.com/Stebalien/tempfile). Please see [this issue](https://github.com/Stebalien/tempfile/issues/43) to track progress and direct new issues and pull requests to `tempfile`.
-
-A Rust library for creating a temporary directory and deleting its entire
-contents when the directory is dropped.
 
 ## Usage
 


### PR DESCRIPTION
cc @steveklabnik @Stebalien

This PR adds a note to the readme here about the merge with `tempfile` and directs new issues and pull requests to be opened there.

I've also added a link to https://github.com/Stebalien/tempfile/issues/43 so folks can see when a release is available.

What do you think? I'm happy to tweak this wording.